### PR TITLE
WAZO-3143-asterisk-exporter

### DIFF
--- a/etc/asterisk/prometheus.conf
+++ b/etc/asterisk/prometheus.conf
@@ -1,0 +1,4 @@
+[general]
+enabled = yes
+core_metrics_enabled = yes
+uri = metrics

--- a/etc/nginx/locations/https-available/asterisk-metrics
+++ b/etc/nginx/locations/https-available/asterisk-metrics
@@ -1,0 +1,8 @@
+location = /api/asterisk/metrics {
+    proxy_pass http://127.0.0.1:5039/metrics;
+
+    proxy_set_header    Host                $http_host;
+    proxy_set_header    X-Script-Name       /api/asterisk;
+    proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+    proxy_set_header    X-Forwarded-Proto   $scheme;
+}

--- a/wazo/plugin.yml
+++ b/wazo/plugin.yml
@@ -1,7 +1,7 @@
 
 name: wazo-prometheus-exporter
 namespace: wazoplatform
-version: 0.0.2
+version: 0.0.3
 author: Wazo authors
 display_name: Prometheus Metrics
 min_wazo_version: 23.02

--- a/wazo/rules
+++ b/wazo/rules
@@ -19,8 +19,9 @@ case "$1" in
         systemctl restart wazo-chatd || :
         systemctl restart wazo-sysconfd || :
         ln -sf  /etc/nginx/locations/https-available/wazo-sysconfd /etc/nginx/locations/https-enabled/wazo-sysconfd
+        ln -sf  /etc/nginx/locations/https-available/asterisk-metrics /etc/nginx/locations/https-enabled/asterisk-metrics
         systemctl nginx reload || :
-
+        asterisk -rx 'module load res_prometheus' || :
         ;;
 
     uninstall)
@@ -30,7 +31,9 @@ case "$1" in
         systemctl restart wazo-chatd || :
         systemctl restart wazo-sysconfd || :
         rm -f /etc/nginx/locations/https-enabled/wazo-sysconfd
+        rm -f /etc/nginx/locations/https-enabled/asterisk-metrics
         systemctl nginx reload || :
+        asterisk -rx 'module unload res_prometheus' || :
         ;;
 
     *)


### PR DESCRIPTION
The installation can be tested with the following commands
`export TOKEN=$(wazo-auth-cli token create)`
`curl -ki -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' --header "X-Auth-Token: $TOKEN" -d '{"method": "git", "options": {"url": "https://github.com/wazo-platform/wazo-prometheus-exporter-plugin.git", "ref": "WAZO-3143-asterisk-exporter"}}' 'https://localhost/api/plugind/0.2/plugins`

After the installation you'll be able to fetch the metrics from asterisk using the following command
`curl -ki  "https://<HOSTNAME>/api/asterisk/metrics"`