### PR TITLE
WP-1833-fix-postgres-exporter-role

### DIFF
--- a/etc/systemd/system/postgres_exporter.service
+++ b/etc/systemd/system/postgres_exporter.service
@@ -11,11 +11,11 @@ ExecStartPre=-/usr/bin/docker rm %n
 ExecStartPre=/usr/bin/docker pull quay.io/prometheuscommunity/postgres-exporter
 ExecStart=/usr/bin/docker run \
     --rm \
-    --name %n \
+    --name=%n \
     --network=host \
-    --env DATA_SOURCE_URI="localhost:5432/postgres?sslmode=disable" \
-    --env DATA_SOURCE_USER="postgres_exporter" \
-    --env DATA_SOURCE_PASS="postgres-exporter-password" \
+    --env=DATA_SOURCE_URI="localhost:5432/postgres?sslmode=disable" \
+    --env=DATA_SOURCE_USER="postgres_exporter" \
+    --env=DATA_SOURCE_PASS="postgres-exporter-password" \
     quay.io/prometheuscommunity/postgres-exporter --web.listen-address=127.0.0.1:9187
 
 [Install]

--- a/etc/systemd/system/postgres_exporter.service
+++ b/etc/systemd/system/postgres_exporter.service
@@ -13,9 +13,9 @@ ExecStart=/usr/bin/docker run \
     --rm \
     --name %n \
     --network=host \
-    --env DATA_SOURCE_URI="localhost:5432/asterisk?sslmode=disable" \
-    --env DATA_SOURCE_USER="asterisk" \
-    --env DATA_SOURCE_PASS="proformatique" \
+    --env DATA_SOURCE_URI="localhost:5432/postgres?sslmode=disable" \
+    --env DATA_SOURCE_USER="postgres_exporter" \
+    --env DATA_SOURCE_PASS="postgres-exporter-password" \
     quay.io/prometheuscommunity/postgres-exporter --web.listen-address=127.0.0.1:9187
 
 [Install]

--- a/etc/systemd/system/process_exporter.service
+++ b/etc/systemd/system/process_exporter.service
@@ -11,11 +11,11 @@ ExecStartPre=-/usr/bin/docker rm %n
 ExecStartPre=/usr/bin/docker pull ncabatoff/process-exporter
 ExecStart=/usr/bin/docker run \
     --rm \
-    --name %n \
-    --publish 127.0.0.1:9256:9256 \
+    --name=%n \
+    --publish=127.0.0.1:9256:9256 \
     --privileged \
-    --volume /proc:/host/proc:ro \
-    --volume /etc/process_exporter:/config:ro \
+    --volume=/proc:/host/proc:ro \
+    --volume=/etc/process_exporter:/config:ro \
     ncabatoff/process-exporter --procfs /host/proc -config.path /config/process.yml
 
 [Install]

--- a/etc/systemd/system/rabbitmq_exporter.service
+++ b/etc/systemd/system/rabbitmq_exporter.service
@@ -11,9 +11,9 @@ ExecStartPre=-/usr/bin/docker rm %n
 ExecStartPre=/usr/bin/docker pull kbudde/rabbitmq-exporter
 ExecStart=/usr/bin/docker run \
     --rm \
-    --name %n \
+    --name=%n \
     --network=host \
-    --env RABBIT_URL=http://localhost:15672 \
+    --env=RABBIT_URL=http://localhost:15672 \
     kbudde/rabbitmq-exporter
 
 [Install]

--- a/wazo/rules
+++ b/wazo/rules
@@ -54,6 +54,13 @@ case "$1" in
         # publishing progress.
         systemctl restart rabbitmq-server || :
 
+        sudo -u postgres psql << EOF
+CREATE USER postgres_exporter WITH PASSWORD 'postgres-exporter-password';
+ALTER USER postgres_exporter SET SEARCH_PATH TO postgres_exporter,pg_catalog;
+GRANT CONNECT ON DATABASE postgres TO postgres_exporter;
+GRANT pg_monitor to postgres_exporter;
+EOF
+
         sed -i '/ARGS=/c\ARGS="-nginx.scrape-uri http://127.0.0.1:8080/status"' /etc/default/prometheus-nginx-exporter
         useradd -rs /bin/false node_exporter
         for service in "${new_services[@]}"; do
@@ -76,6 +83,11 @@ case "$1" in
         # publishing progress.
         rm -f /etc/rabbitmq/enabled_plugins
         systemctl restart rabbitmq-server || :
+
+        sudo -u postgres psql << EOF
+REVOKE CONNECT ON DATABASE postgres FROM postgres_exporter;
+DROP ROLE postgres_exporter;
+EOF
 
         for service in "${new_services[@]}"; do
             systemctl restart "$service" || :


### PR DESCRIPTION
why: asterisk user missing pg_monitor role
Instead of continuing to use asterisk as workaround, we also dedicate a
user for the exporter
