### PR TITLE
WP-1909-fix-nginx-exporter

### DIFF
--- a/etc/nginx/locations/https-available/nginx-metrics
+++ b/etc/nginx/locations/https-available/nginx-metrics
@@ -1,5 +1,5 @@
 location = /api/nginx/metrics {
-    proxy_pass http://127.0.0.1:8080/status;
+    proxy_pass http://127.0.0.1:9113/metrics;
 
     proxy_set_header    Host                $http_host;
     proxy_set_header    X-Script-Name       /api/nginx;

--- a/wazo/rules
+++ b/wazo/rules
@@ -62,6 +62,8 @@ GRANT pg_monitor to postgres_exporter;
 EOF
 
         sed -i '/ARGS=/c\ARGS="-nginx.scrape-uri http://127.0.0.1:8080/status"' /etc/default/prometheus-nginx-exporter
+        systemctl restart prometheus-nginx-exporter
+
         useradd -rs /bin/false node_exporter
         for service in "${new_services[@]}"; do
             systemctl enable "$service" || :


### PR DESCRIPTION
- local /status is internal metrics from nginx, not formatted for
  prometheus
- prometheus-nginx-exporter processes take those metrics and expose them
  in a "prometheus" format
- restart prometheus-nginx-exporter after changing arguments
