### PR TITLE
nginx exporter: reload nginx before the exporter

### DIFF
--- a/wazo/rules
+++ b/wazo/rules
@@ -61,11 +61,6 @@ GRANT CONNECT ON DATABASE postgres TO postgres_exporter;
 GRANT pg_monitor to postgres_exporter;
 EOF
 
-        # nginx status needs to be available for the nginx-exporter to start
-        systemctl reload nginx || :
-        sed -i '/ARGS=/c\ARGS="-nginx.scrape-uri http://127.0.0.1:8080/status"' /etc/default/prometheus-nginx-exporter
-        systemctl restart prometheus-nginx-exporter
-
         useradd -rs /bin/false node_exporter
         for service in "${new_services[@]}"; do
             systemctl enable "$service" || :
@@ -80,6 +75,10 @@ EOF
         ln -sf /etc/nginx/sites-available/nginx-metrics /etc/nginx/sites-enabled/nginx-metrics
         asterisk -rx 'module load res_prometheus' || :
         systemctl reload nginx || :
+
+        sed -i '/ARGS=/c\ARGS="-nginx.scrape-uri http://127.0.0.1:8080/status"' /etc/default/prometheus-nginx-exporter
+        systemctl reset-failed prometheus-nginx-exporter
+        systemctl restart prometheus-nginx-exporter
         ;;
 
     uninstall)

--- a/wazo/rules
+++ b/wazo/rules
@@ -69,11 +69,13 @@ EOF
         for service in "${to_restart[@]}"; do
             systemctl restart "$service" || :
         done
+
+        asterisk -rx 'module load res_prometheus' || :
+
         for filename in "${nginx_locations[@]}"; do
             ln -sf "/etc/nginx/locations/https-available/$filename" "/etc/nginx/locations/https-enabled/$filename"
         done
         ln -sf /etc/nginx/sites-available/nginx-metrics /etc/nginx/sites-enabled/nginx-metrics
-        asterisk -rx 'module load res_prometheus' || :
         systemctl reload nginx || :
 
         sed -i '/ARGS=/c\ARGS="-nginx.scrape-uri http://127.0.0.1:8080/status"' /etc/default/prometheus-nginx-exporter

--- a/wazo/rules
+++ b/wazo/rules
@@ -61,6 +61,8 @@ GRANT CONNECT ON DATABASE postgres TO postgres_exporter;
 GRANT pg_monitor to postgres_exporter;
 EOF
 
+        # nginx status needs to be available for the nginx-exporter to start
+        systemctl reload nginx || :
         sed -i '/ARGS=/c\ARGS="-nginx.scrape-uri http://127.0.0.1:8080/status"' /etc/default/prometheus-nginx-exporter
         systemctl restart prometheus-nginx-exporter
 


### PR DESCRIPTION
prometheus-nginx-exporter fails to start if :8080/status is not available when it starts. Doing a reload first will allow the nginx-metrics site to be available