### PR TITLE
WAZO-4177-expose-metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,24 @@ wazo-plugind-cli -c "install git https://github.com/wazo-platform/wazo-prometheu
 
 ## Metrics endpoints
 
-* asterisk `/api/asterisk/metrics`
-* nginx `/api/nginx/metrics`
-* rabbitmq `/api/rabbitmq/metrics`
-* wazo-agentd `/api/agentd/1.0/metrics`
-* wazo-amid `/api/amid/1.0/metrics`
-* wazo-auth `/api/auth/0.1/metrics`
-* wazo-call-logd `api/call-logd/1.0/metrics`
-* wazo-calld `/api/calld/1.0/metrics`
-* wazo-chatd `/api/chatd/1.0/metrics`
-* wazo-confd `/api/confd/1.1/metrics`
-* wazo-dird `/api/dird/0.1/metrics`
-* wazo-phoned `/api/phoned/0.1/metrics`
-* wazo-sysconfd `/api/sysconfd/metrics`
-* wazo-webhookd `/api/webhookd/1.0/metrics`
+> [!WARNING]
+> Internal metrics will be available on **port 6387**. This port must be closed
+> by a firewall to avoid exposing the metrics to the public.
+
+- asterisk `/api/asterisk/metrics`
+- nginx `/api/nginx/metrics`
+- rabbitmq `/api/rabbitmq/metrics`
+- wazo-agentd `/api/agentd/1.0/metrics`
+- wazo-amid `/api/amid/1.0/metrics`
+- wazo-auth `/api/auth/0.1/metrics`
+- wazo-call-logd `api/call-logd/1.0/metrics`
+- wazo-calld `/api/calld/1.0/metrics`
+- wazo-chatd `/api/chatd/1.0/metrics`
+- wazo-confd `/api/confd/1.1/metrics`
+- wazo-dird `/api/dird/0.1/metrics`
+- wazo-phoned `/api/phoned/0.1/metrics`
+- wazo-sysconfd `/api/sysconfd/metrics`
+- wazo-webhookd `/api/webhookd/1.0/metrics`
 
 ## Prometheus scrape config
 

--- a/contrib/self-check.sh
+++ b/contrib/self-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-hostname="${1:localhost}"
+hostname="${1:-localhost}"
 
 METRICS=$(cat <<- EOV
     /amid/1.0/metrics

--- a/contrib/self-check.sh
+++ b/contrib/self-check.sh
@@ -3,28 +3,28 @@
 hostname="${1:localhost}"
 
 METRICS=$(cat <<- EOV
-    /api/amid/1.0/metrics
-    /api/asterisk/metrics
-    /api/auth/0.1/metrics
-    /api/call-logd/1.0/metrics
-    /api/calld/1.0/metrics
-    /api/chatd/1.0/metrics
-    /api/confd/1.1/metrics
-    /api/dird/0.1/metrics
-    /api/nginx/metrics
-    /api/node/metrics
-    /api/phoned/0.1/metrics
-    /api/postgresql/metrics
-    /api/rabbitmq/metrics
-    /api/sysconfd/metrics
-    /api/sysconfd/metrics
-    /api/webhookd/1.0/metrics
+    /amid/1.0/metrics
+    /asterisk/metrics
+    /auth/0.1/metrics
+    /call-logd/1.0/metrics
+    /calld/1.0/metrics
+    /chatd/1.0/metrics
+    /confd/1.1/metrics
+    /dird/0.1/metrics
+    /nginx/metrics
+    /node/metrics
+    /phoned/0.1/metrics
+    /postgresql/metrics
+    /rabbitmq/metrics
+    /sysconfd/metrics
+    /sysconfd/metrics
+    /webhookd/1.0/metrics
 EOV
 )
 
 result=0
 for metric in $METRICS; do
-    url="https://${hostname}${metric}"
+    url="http://${hostname}:6387${metric}"
     for i in {1..60}; do
         if curl -skf -o /dev/null "$url"; then
             echo "${url} OK"

--- a/etc/nginx/locations/https-available/asterisk-metrics
+++ b/etc/nginx/locations/https-available/asterisk-metrics
@@ -1,8 +1,0 @@
-location = /api/asterisk/metrics {
-    proxy_pass http://127.0.0.1:5039/metrics;
-
-    proxy_set_header    Host                $http_host;
-    proxy_set_header    X-Script-Name       /api/asterisk;
-    proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
-    proxy_set_header    X-Forwarded-Proto   $scheme;
-}

--- a/etc/nginx/locations/https-available/block-metrics
+++ b/etc/nginx/locations/https-available/block-metrics
@@ -1,0 +1,34 @@
+# Do not expose metrics endpoints on port 443
+
+location = /api/agentd/1.0/metrics {
+    deny all;
+}
+location = /api/amid/1.0/metrics {
+    deny all;
+}
+location = /api/auth/0.1/metrics {
+    deny all;
+}
+location = /api/calld/1.0/metrics {
+    deny all;
+}
+location = /api/chatd/1.0/metrics {
+    deny all;
+}
+location = /api/confd/1.1/metrics {
+    deny all;
+}
+location = /api/call-logd/1.0/metrics {
+    deny all;
+}
+location = /api/dird/0.1/metrics {
+    deny all;
+}
+location = /api/webhookd/1.0/metrics {
+    deny all;
+}
+
+# Future proof
+location = /api/phoned/0.1/metrics {
+    deny all;
+}

--- a/etc/nginx/locations/https-available/nginx-metrics
+++ b/etc/nginx/locations/https-available/nginx-metrics
@@ -1,8 +1,0 @@
-location = /api/nginx/metrics {
-    proxy_pass http://127.0.0.1:9113/metrics;
-
-    proxy_set_header    Host                $http_host;
-    proxy_set_header    X-Script-Name       /api/nginx;
-    proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
-    proxy_set_header    X-Forwarded-Proto   $scheme;
-}

--- a/etc/nginx/locations/https-available/node-metrics
+++ b/etc/nginx/locations/https-available/node-metrics
@@ -1,8 +1,0 @@
-location = /api/node/metrics {
-    proxy_pass http://127.0.0.1:9100/metrics;
-
-    proxy_set_header    Host                $http_host;
-    proxy_set_header    X-Script-Name       /api/node;
-    proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
-    proxy_set_header    X-Forwarded-Proto   $scheme;
-}

--- a/etc/nginx/locations/https-available/postgres-metrics
+++ b/etc/nginx/locations/https-available/postgres-metrics
@@ -1,8 +1,0 @@
-location = /api/postgresql/metrics {
-    proxy_pass http://127.0.0.1:9187/metrics;
-
-    proxy_set_header    Host                $http_host;
-    proxy_set_header    X-Script-Name       /api/postgresql;
-    proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
-    proxy_set_header    X-Forwarded-Proto   $scheme;
-}

--- a/etc/nginx/locations/https-available/process-metrics
+++ b/etc/nginx/locations/https-available/process-metrics
@@ -1,8 +1,0 @@
-location = /api/process/metrics {
-    proxy_pass http://127.0.0.1:9256/metrics;
-
-    proxy_set_header    Host                $http_host;
-    proxy_set_header    X-Script-Name       /api/process;
-    proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
-    proxy_set_header    X-Forwarded-Proto   $scheme;
-}

--- a/etc/nginx/locations/https-available/rabbitmq-metrics
+++ b/etc/nginx/locations/https-available/rabbitmq-metrics
@@ -1,8 +1,0 @@
-location = /api/rabbitmq/metrics {
-    proxy_pass http://127.0.0.1:9419/metrics;
-
-    proxy_set_header    Host                $http_host;
-    proxy_set_header    X-Script-Name       /api/rabbitmq;
-    proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
-    proxy_set_header    X-Forwarded-Proto   $scheme;
-}

--- a/etc/nginx/locations/https-available/wazo-phoned-metrics
+++ b/etc/nginx/locations/https-available/wazo-phoned-metrics
@@ -1,8 +1,0 @@
-location = /api/phoned/0.1/metrics {
-    proxy_pass http://127.0.0.1:9498/0.1/metrics;
-
-    proxy_set_header    Host                $http_host;
-    proxy_set_header    X-Script-Name       /api/phoned;
-    proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
-    proxy_set_header    X-Forwarded-Proto   $scheme;
-}

--- a/etc/nginx/locations/https-available/wazo-sysconfd
+++ b/etc/nginx/locations/https-available/wazo-sysconfd
@@ -1,8 +1,0 @@
-location = /api/sysconfd/metrics {
-    proxy_pass http://127.0.0.1:8668/metrics;
-
-    proxy_set_header    Host                $http_host;
-    proxy_set_header    X-Script-Name       /api/sysconfd;
-    proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
-    proxy_set_header    X-Forwarded-Proto   $scheme;
-}

--- a/etc/nginx/sites-available/zzz-proxy-metrics
+++ b/etc/nginx/sites-available/zzz-proxy-metrics
@@ -1,0 +1,92 @@
+# File name must follow 'wazo' drop-in file to define log_format 'main'
+
+server {
+    listen 6387 default_server;
+    listen [::]:6387 default_server;
+    server_name _;
+
+    access_log /var/log/nginx/wazo.access.log main;
+    error_log /var/log/nginx/wazo.error.log;
+    root /var/www/html;
+
+    location / {
+        proxy_set_header    Host                $http_host;
+        proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+        proxy_set_header    X-Forwarded-Proto   $scheme;
+        proxy_set_header    X-Script-Name       $prefix;
+
+        # Third-party metrics
+        location = /asterisk/metrics {
+            proxy_pass http://127.0.0.1:5039/metrics;
+            set $prefix asterisk;
+        }
+        location = /nginx/metrics {
+            proxy_pass http://127.0.0.1:9113/metrics;
+            set $prefix nginx;
+        }
+        location = /node/metrics {
+            proxy_pass http://127.0.0.1:9100/metrics;
+            set $prefix node;
+        }
+        location = /postgresql/metrics {
+            proxy_pass http://127.0.0.1:9187/metrics;
+            set $prefix postgresql;
+        }
+        location = /process/metrics {
+            proxy_pass http://127.0.0.1:9256/metrics;
+            set $prefix process;
+        }
+        location = /rabbitmq/metrics {
+            proxy_pass http://127.0.0.1:9419/metrics;
+            set $prefix rabbitmq;
+        }
+
+        # Wazo metrics
+        location = /agentd/1.0/metrics {
+            proxy_pass http://127.0.0.1:9493/1.0/metrics;
+            set $prefix agentd;
+        }
+        location = /amid/1.0/metrics {
+            proxy_pass http://127.0.0.1:9491/1.0/metrics;
+            set $prefix amid;
+        }
+        location = /auth/0.1/metrics {
+            proxy_pass http://127.0.0.1:9497/0.1/metrics;
+            set $prefix auth;
+        }
+        location = /calld/1.0/metrics {
+            proxy_pass http://127.0.0.1:9500/1.0/metrics;
+            set $prefix calld;
+        }
+        location = /chatd/1.0/metrics {
+            proxy_pass http://127.0.0.1:9304/1.0/metrics;
+            set $prefix chatd;
+        }
+        location = /confd/1.1/metrics {
+            proxy_pass http://127.0.0.1:9486/1.1/metrics;
+            set $prefix confd;
+        }
+        location = /call-logd/1.0/metrics {
+            proxy_pass http://127.0.0.1:9298/1.0/metrics;
+            set $prefix call-logd;
+        }
+        location = /dird/0.1/metrics {
+            proxy_pass http://127.0.0.1:9489/0.1/metrics;
+            set $prefix dird;
+        }
+        location = /phoned/0.1/metrics {
+            proxy_pass http://127.0.0.1:9498/0.1/metrics;
+            set $prefix phoned;
+        }
+        location = /webhookd/1.0/metrics {
+            proxy_pass http://127.0.0.1:9300/1.0/metrics;
+            set $prefix webhookd;
+        }
+
+        location = /sysconfd/metrics {
+            proxy_pass http://127.0.0.1:8668/metrics;
+            set $prefix sysconfd;
+        }
+
+    }
+}

--- a/wazo/rules
+++ b/wazo/rules
@@ -2,16 +2,6 @@
 # Copyright 2023-2025 Wazo Team (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 
-declare -a nginx_locations=(
-    "wazo-sysconfd"
-    "wazo-phoned-metrics"
-    "asterisk-metrics"
-    "rabbitmq-metrics"
-    "postgres-metrics"
-    "node-metrics"
-    "nginx-metrics"
-    "process-metrics"
-)
 declare -a new_services=(
     "rabbitmq_exporter"
     "postgres_exporter"
@@ -72,10 +62,9 @@ EOF
 
         asterisk -rx 'module load res_prometheus' || :
 
-        for filename in "${nginx_locations[@]}"; do
-            ln -sf "/etc/nginx/locations/https-available/$filename" "/etc/nginx/locations/https-enabled/$filename"
-        done
+        ln -sf /etc/nginx/locations/https-available/block-metrics /etc/nginx/locations/https-enabled/block-metrics
         ln -sf /etc/nginx/sites-available/nginx-metrics /etc/nginx/sites-enabled/nginx-metrics
+        ln -sf /etc/nginx/sites-available/zzz-proxy-metrics /etc/nginx/sites-enabled/zzz-proxy-metrics
         systemctl reload nginx || :
 
         sed -i '/ARGS=/c\ARGS="-nginx.scrape-uri http://127.0.0.1:8080/status"' /etc/default/prometheus-nginx-exporter
@@ -97,12 +86,14 @@ EOF
         for service in "${new_services[@]}"; do
             systemctl restart "$service" || :
         done
-        for filename in "${nginx_locations[@]}"; do
-            rm -f "/etc/nginx/locations/https-enabled/$filename"
-        done
+
+        rm -f /etc/nginx/locations/https-enabled/block-metrics
         rm -f /etc/nginx/sites-enabled/nginx-metrics
-        asterisk -rx 'module unload res_prometheus' || :
+        rm -f /etc/nginx/sites-enabled/zzz-proxy-metrics
         systemctl reload nginx || :
+
+        asterisk -rx 'module unload res_prometheus' || :
+
         for service in "${new_services[@]}"; do
             systemctl stop "$service" || :
             systemctl disable "$service" || :

--- a/wazo_prometheus_exporter/plugins/flask/metric/plugin.py
+++ b/wazo_prometheus_exporter/plugins/flask/metric/plugin.py
@@ -2,23 +2,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
-import re
 
 from prometheus_flask_exporter import PrometheusMetrics
 
 logger = logging.getLogger(__name__)
-
-TOKEN_URL_RE = re.compile(r"/token/([a-zA-Z0-9-]+)")
-ANONYMIZED_TOKEN = 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX'
-
-
-def path(req):
-    matches = TOKEN_URL_RE.search(req.path)
-    if matches:
-        token = matches.group(1)
-        return req.path.replace(token, ANONYMIZED_TOKEN)
-
-    return req.path
 
 
 class Plugin:
@@ -27,4 +14,4 @@ class Plugin:
 
         path = f'{api.prefix}/metrics'
         logger.debug('Registering Prometheus metrics endpoint at %s', path)
-        self.metrics = PrometheusMetrics(api.app, path=path, group_by='endpoint')
+        PrometheusMetrics(api.app, path=path, group_by='endpoint')

--- a/wazo_prometheus_exporter/plugins/flask/metric/plugin.py
+++ b/wazo_prometheus_exporter/plugins/flask/metric/plugin.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from prometheus_flask_exporter import PrometheusMetrics
+from prometheus_flask_exporter import RESTfulPrometheusMetrics
 
 logger = logging.getLogger(__name__)
 
@@ -14,4 +14,4 @@ class Plugin:
 
         path = f'{api.prefix}/metrics'
         logger.debug('Registering Prometheus metrics endpoint at %s', path)
-        PrometheusMetrics(api.app, path=path, group_by='endpoint')
+        RESTfulPrometheusMetrics(api.app, api, path=path, group_by='endpoint')


### PR DESCRIPTION
- **remove unused code from flask exporter**
- **Use RestfulPrometheusMetrics to handle corner case**
- **expose metrics on port 6387 instead of 443**
