### PR TITLE
fix-depends

### DIFF
--- a/wazo/plugin.yml
+++ b/wazo/plugin.yml
@@ -9,9 +9,6 @@ tags:
   - metrics
 homepage: https://github.com/wazo-platform/wazo-prometheus-exporter-plugin
 debian_depends:
-  - python3-build
-  - python3-pip
-  - python3-venv
   - python3-prometheus-flask-exporter
   - python3-starlette-exporter
   - prometheus-nginx-exporter


### PR DESCRIPTION
why: they are used for build/package steps, not as runtime dependencies

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines `debian_depends` in `wazo/plugin.yml` by dropping build-time packages, keeping only runtime dependencies.
> 
> - **Config**:
>   - Update `wazo/plugin.yml` to remove build-time packages (`python3-build`, `python3-pip`, `python3-venv`) from `debian_depends`.
>   - Retain only runtime deps: `python3-prometheus-flask-exporter`, `python3-starlette-exporter`, `prometheus-nginx-exporter`, `docker.io`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd9b8f682a148cddced478ee4e3ffe1e6117c93d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->